### PR TITLE
Remove deprecated YARP headers

### DIFF
--- a/AME/amedriver.h
+++ b/AME/amedriver.h
@@ -9,7 +9,7 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
 #include <yarp/sig/Vector.h>
 

--- a/ATI_Ethernet/CMakeLists.txt
+++ b/ATI_Ethernet/CMakeLists.txt
@@ -14,7 +14,6 @@ if(ENABLE_ati_ethernet)
 	find_package(TinyXML REQUIRED)
 
 	yarp_add_plugin(ati_ethernet ati_ethernetDriver.cpp ati_ethernetDriver.h)
-        include_directories(${YARP_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 
 	target_link_libraries(ati_ethernet ${YARP_LIBRARIES} ${TinyXML_LIBRARIES})
 

--- a/ATI_Ethernet/ati_ethernetDriver.h
+++ b/ATI_Ethernet/ati_ethernetDriver.h
@@ -12,7 +12,7 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # Find YARP and include the CMake code to compile plugins
 find_package(YARP REQUIRED)
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
-include(YarpPlugin)
-include(YarpInstallationHelpers)
 
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE)
 

--- a/amti/include/AMTIForcePlate.h
+++ b/amti/include/AMTIForcePlate.h
@@ -8,9 +8,10 @@
 #define YARP_AMTIFORCEPLATE_H
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/sig/Matrix.h>
 
 #include <iDynTree/Core/Transform.h>

--- a/amti/include/AMTIPlatformsDriver.h
+++ b/amti/include/AMTIPlatformsDriver.h
@@ -9,7 +9,7 @@
 #define YARP_AMTIPLATFORMSDRIVER_H
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include "IMultipleForcePlates.h"
 
 #include <yarp/sig/Vector.h>

--- a/forcetorqueDriverExample/forcetorqueDriverExample.h
+++ b/forcetorqueDriverExample/forcetorqueDriverExample.h
@@ -10,7 +10,7 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
 #include <yarp/sig/Vector.h>
 

--- a/ftNode/CMakeLists.txt
+++ b/ftNode/CMakeLists.txt
@@ -14,7 +14,6 @@ if (ENABLE_ftnode)
 
     yarp_add_plugin(ftnode ftnodeDriver.cpp ftnodeDriver.h)
 
-    include_directories(${YARP_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(ftnode ${YARP_LIBRARIES})
     yarp_install(TARGETS ftnode
                  COMPONENT runtime

--- a/ftNode/ftnodeDriver.h
+++ b/ftNode/ftnodeDriver.h
@@ -9,10 +9,11 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/Wrapper.h>
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/ISerialDevice.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/PeriodicThread.h>
 
 

--- a/ftShoe/CMakeLists.txt
+++ b/ftShoe/CMakeLists.txt
@@ -15,7 +15,6 @@ if(ENABLE_ftshoe)
 
     yarp_add_plugin(ftshoe ftshoeDriver.cpp ftshoeDriver.h)
 
-    include_directories(${YARP_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(ftshoe ${YARP_LIBRARIES})
     yarp_install(TARGETS ftshoe
                  COMPONENT runtime

--- a/ftShoe/ftshoeDriver.h
+++ b/ftShoe/ftshoeDriver.h
@@ -10,10 +10,10 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
-#include <yarp/dev/Wrapper.h>
-#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>

--- a/ftShoeUdpWrapper/CMakeLists.txt
+++ b/ftShoeUdpWrapper/CMakeLists.txt
@@ -15,7 +15,6 @@ if(ENABLE_ftShoeUdpWrapper)
     yarp_add_plugin(ftShoeUdpWrapper ftShoeUdpWrapper.cpp ftShoeUdpWrapper.h)
 
     target_include_directories(ftShoeUdpWrapper PUBLIC
-        ${YARP_INCLUDE_DIRS}
         ${Asio_INCLUDE_DIRS}
         ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(ftShoeUdpWrapper ${YARP_LIBRARIES})

--- a/ftShoeUdpWrapper/ftShoeUdpWrapper.cpp
+++ b/ftShoeUdpWrapper/ftShoeUdpWrapper.cpp
@@ -7,7 +7,7 @@
 #include "ftShoeUdpWrapper.h"
 
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Property.h>
 #include <yarp/sig/Vector.h>

--- a/ftShoeUdpWrapper/ftShoeUdpWrapper.h
+++ b/ftShoeUdpWrapper/ftShoeUdpWrapper.h
@@ -8,8 +8,8 @@
 #define YARP_ftShoeUdpWrapper_H
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <yarp/os/PeriodicThread.h>
 

--- a/optoforce/optoforceDriver.h
+++ b/optoforce/optoforceDriver.h
@@ -10,7 +10,7 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAnalogSensor.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
 #include <yarp/sig/Vector.h>
 


### PR DESCRIPTION
This PR addresses https://github.com/robotology/yarp-devices-forcetorque/issues/35.

I took advantage of this PR also to remove the deprecated use of some instructions in the CMakeLists (dd7c525ed6f48d203e6e6be80dacf938c56f6186).

I tried compiling everything and now I don't get any warning from CMake.