### PR TITLE
Add CI with conda dependencies

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -GNinja -DBUILD_TESTING:BOOL=ON \
+        cmake -GNinja \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DENABLE_ati_ethernet:BOOL=ON \
               -DENABLE_ftShoeUdpWrapper:BOOL=ON \
@@ -52,7 +52,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 17 2022" -DBUILD_TESTING:BOOL=ON \
+        cmake -G"Visual Studio 17 2022" \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DENABLE_ati_ethernet:BOOL=ON \
               -DENABLE_ftShoeUdpWrapper:BOOL=ON \

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -30,10 +30,8 @@ jobs:
     - name: Dependencies
       shell: bash -l {0}
       run: |
-        # Compilation related dependencies
-        mamba install cmake compilers make ninja pkg-config
-        # Actual dependencies
-        mamba install -c conda-forge -c robotology yarp asio
+        # Install dependencies
+        mamba install cmake compilers make ninja pkg-config asio yarp
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -1,0 +1,69 @@
+name: C++ CI Workflow with conda dependencies
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *'
+
+jobs:
+  build:
+    name: '[${{ matrix.os }}@${{ matrix.build_type }}@conda]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build_type: [Release]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
+
+    - name: Dependencies
+      shell: bash -l {0}
+      run: |
+        # Compilation related dependencies
+        mamba install cmake compilers make ninja pkg-config
+        # Actual dependencies
+        mamba install -c conda-forge -c robotology yarp
+
+    - name: Configure [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DENABLE_ati_ethernet:BOOL=ON \
+              -DENABLE_ftShoeUdpWrapper:BOOL=ON \
+              -DENABLE_ftnode:BOOL=ON \
+              -DENABLE_ftshoe:BOOL=ON ..
+
+    - name: Configure [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -G"Visual Studio 17 2022" -DBUILD_TESTING:BOOL=ON \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DENABLE_ati_ethernet:BOOL=ON \
+              -DENABLE_ftShoeUdpWrapper:BOOL=ON \
+              -DENABLE_ftnode:BOOL=ON \
+              -DENABLE_ftshoe:BOOL=ON ..
+
+    - name: Build
+      shell: bash -l {0}
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -34,7 +34,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge -c robotology yarp
+        mamba install -c conda-forge -c robotology yarp asio
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -24,9 +24,8 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        mamba-version: "*"
-        channels: conda-forge,defaults
-        channel-priority: true
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
 
     - name: Dependencies
       shell: bash -l {0}

--- a/AME/ethService.h
+++ b/AME/ethService.h
@@ -24,7 +24,6 @@
 #include <cstdint>
 #include <type_traits>
 
-#include <unistd.h>
 #include <netinet/in.h>
 
 #include "rehab.h"

--- a/AME/osutil.cpp
+++ b/AME/osutil.cpp
@@ -18,7 +18,7 @@
 
 #include <dirent.h>
 #include <sys/stat.h>
-#include <unistd.h>
+#include <thread>
 
 namespace rehab {
 

--- a/ATI_Ethernet/ati_ethernetDriver.h
+++ b/ATI_Ethernet/ati_ethernetDriver.h
@@ -28,9 +28,9 @@
 	#include <arpa/inet.h>
     #include <sys/socket.h>
 	#include <netdb.h>
+    #include <unistd.h>
 #endif
 
-#include <unistd.h>
 #include <sys/types.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
This PR addresses https://github.com/robotology/yarp-devices-forcetorque/issues/32.

The workflow uses dependencies installed via `conda` and builds all the software in the repo that can be built without external SDK (e.g. does not build the AMTI FT platform related software).