### PR TITLE
Switch mantainer to traversaro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners
-*       @lrapetti
+*       @traversaro

--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Maintainers
 --------------
 This repository is maintained by:
 
-* Lorenzo Rapetti ([@lrapetti](https://github.com/lrapetti))
+* Silvio Traversaro ([@traversaro](https://github.com/traversaro))


### PR DESCRIPTION
I guess we are going to deprecate and archive the repo soon nevertheless, so I can just take it over myself.